### PR TITLE
Space in path fix

### DIFF
--- a/src/sadie/app.py
+++ b/src/sadie/app.py
@@ -13,7 +13,7 @@ from sadie.utility import SadieIO
 from sadie.utility.util import get_verbosity_level, get_project_root
 
 # reference
-from sadie.reference import make_germline_database, Reference
+from sadie.reference import make_germline_database, Reference, write_blast_db
 
 
 @click.group()
@@ -162,6 +162,32 @@ def make_igblast_reference(verbose, outpath, reference):
     germline_path = make_germline_database(reference_object, outpath)
     click.echo(f"Wrote germline database to {germline_path}")
     click.echo("Done!")
+
+
+@reference.command("makeblastdb")
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    default=4,
+    help="Vebosity level, ex. -vvvvv for debug level logging",
+)
+@click.option(
+    "--inpath",
+    "-i",
+    help="Input path to Fasta file",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "--outpath",
+    "-o",
+    help="Output path to generate blast_db, internal_data and auxillary files",
+    type=click.Path(resolve_path=True, dir_okay=True, writable=True),
+)
+def write_single_blast_db(verbose, inpath, outpath):
+    numeric_level = get_verbosity_level(verbose)
+    logging.basicConfig(level=numeric_level)
+    write_blast_db(inpath, outpath)
 
 
 if __name__ == "__main__":

--- a/src/sadie/reference/__init__.py
+++ b/src/sadie/reference/__init__.py
@@ -1,4 +1,5 @@
 __version__ = "0.4.5"
+from sadie.reference.blast import write_blast_db
 from sadie.reference.reference import Reference
 from sadie.reference.internal_data import make_internal_annotaion_file
 from sadie.reference.igblast_ref import make_igblast_ref_database
@@ -48,4 +49,4 @@ def make_germline_database(reference: Reference, output_path: Path) -> Path:
     return output_path
 
 
-__all__ = ["Reference"]
+__all__ = ["Reference", "write_blast_db"]

--- a/src/sadie/reference/blast.py
+++ b/src/sadie/reference/blast.py
@@ -20,17 +20,17 @@ def write_blast_db(filename: str, output_db: str) -> None:
         Exception: If makeblastdb fails for any reason
     """
     logger = logging.getLogger(__name__)
-    
+
     # Validate Blast makeblastdb executable
     system = platform.system().lower()
     make_blast_db_exe = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"bin/{system}/makeblastdb")
     if not shutil.which(make_blast_db_exe):
         raise Exception(f"Make Blast DB {make_blast_db_exe} cant be found or is not executable")
-    
+
     # Validate inpath fasta file and outpath directory
     filename = pathing(filename)  # make sure file exists
     output_db = pathing(output_db, new=True, overwrite=True)  # makes sure parent directory exists
-    
+
     # Blast does not allow spaces in the path; need to use a temp file/dir
     with tempfile.NamedTemporaryFile(suffix=filename.suffix) as tmp_filename_obj:
         with tempfile.NamedTemporaryFile(suffix=None) as tmp_output_db_obj:
@@ -64,7 +64,7 @@ def write_blast_db(filename: str, output_db: str) -> None:
                 raise Exception(stderr)
             # We use the tmp file not as an actual output but to guarantee a unqiue prefix
             logger.info(f"Copying {tmp_output_db}.* to {output_db}")
-            for tmpfile in tmp_output_db.parent.glob(f"{tmp_output_db.name}.*"):                
+            for tmpfile in tmp_output_db.parent.glob(f"{tmp_output_db.name}.*"):
                 logger.info(f"Copying {tmpfile} to {output_db.with_suffix(tmpfile.suffix)}")
                 shutil.copy(tmpfile, output_db.with_suffix(tmpfile.suffix))
                 tmpfile.unlink()  # we use the tmp file name only as a reference

--- a/src/sadie/reference/blast.py
+++ b/src/sadie/reference/blast.py
@@ -1,11 +1,15 @@
 import logging
 import os
+from pathlib import Path
 import platform
 import subprocess
 import shutil
+import tempfile
+
+logger = logging.getLogger("reference")
 
 
-def write_blast_db(filename, output_db):
+def write_blast_db(filename: str, output_db: str) -> None:
     """Take Input Fasta File
 
     Arguments:
@@ -16,28 +20,82 @@ def write_blast_db(filename, output_db):
         Exception: If makeblastdb fails for any reason
     """
     logger = logging.getLogger(__name__)
+    
+    # Validate Blast makeblastdb executable
     system = platform.system().lower()
     make_blast_db_exe = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"bin/{system}/makeblastdb")
     if not shutil.which(make_blast_db_exe):
         raise Exception(f"Make Blast DB {make_blast_db_exe} cant be found or is not executable")
-    make_blast_db = subprocess.run(
-        [
-            make_blast_db_exe,
-            "-dbtype",
-            "nucl",
-            "-hash_index",
-            "-parse_seqids",
-            "-in",
-            filename,
-            "-out",
-            output_db,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    stdout = make_blast_db.stdout.decode("utf-8")
-    stderr = make_blast_db.stderr.decode("utf-8")
-    logger.debug((stdout))
-    if make_blast_db.returncode:
-        logger.critical("Problem with {}".format(filename))
-        raise Exception(stderr)
+    
+    # Validate inpath fasta file and outpath directory
+    filename = pathing(filename)
+    output_db = pathing(output_db, new=True, overwrite=True)
+    
+    # Blast does not allow spaces in the path; need to use a temp file/dir
+    with tempfile.NamedTemporaryFile(suffix=filename.suffix) as tmp_filename_obj:
+        with tempfile.NamedTemporaryFile(suffix=None) as tmp_output_db_obj:
+            # Only care for the path to the file
+            tmp_filename = Path(tmp_filename_obj.name)
+            tmp_output_db = Path(tmp_output_db_obj.name)
+            # Write the fasta file to the temp file to garuntee no spaces in the path
+            shutil.copy(filename, tmp_filename)
+            # Execute makeblastdb
+            logger.info(f"{make_blast_db_exe} -in {tmp_filename} -dbtype nucl -out {tmp_output_db}")
+            make_blast_db = subprocess.run(
+                [
+                    make_blast_db_exe,
+                    "-dbtype",
+                    "nucl",
+                    "-hash_index",
+                    "-parse_seqids",
+                    "-in",
+                    tmp_filename,
+                    "-out",
+                    tmp_output_db,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout = make_blast_db.stdout.decode("utf-8")
+            stderr = make_blast_db.stderr.decode("utf-8")
+            logger.debug((stdout))
+            if make_blast_db.returncode:
+                logger.critical("Problem with {}".format(filename))
+                raise Exception(stderr)
+            # We use the tmp file not as an actual output but to guarantee a unqiue prefix
+            logger.info(f"Copying {tmp_output_db}.* to {output_db}")
+            for tmpfile in tmp_output_db.parent.glob(f"{tmp_output_db.name}.*"):                
+                logger.info(f"Copying {tmpfile} to {output_db.with_suffix(tmpfile.suffix)}")
+                shutil.copy(tmpfile, output_db.with_suffix(tmpfile.suffix))
+                tmpfile.unlink()  # we use the tmp file name only as a reference
+
+
+def pathing(path: str, new: bool = False, overwrite: bool = True) -> Path:
+    """Guarantees correct expansion rules for pathing.
+
+    :param Union[str, Path] path: path of folder or file you wish to expand.
+    :param bool new: will check if distination exists if new  (will check parent path regardless).
+    :return: A pathlib.Path object.
+
+    >>> pathing('~/Desktop/folderofgoodstuffs/')
+    /home/user/Desktop/folderofgoodstuffs
+    """
+    path = Path(path)
+    # Expand shortened path
+    if str(path)[0] == "~":
+        path = path.expanduser()
+    # Exand local path
+    if str(path)[0] == ".":
+        path = path.resolve()
+    else:
+        path = path.absolute()
+    # Making sure new paths don't exist while also making sure existing paths actually exist.
+    if new:
+        if not path.parent.exists():
+            raise ValueError(f"ERROR ::: Parent directory of {path} does not exist.")
+        if path.exists() and not overwrite:
+            raise ValueError(f"ERROR ::: {path} already exists!")
+    else:
+        if not path.exists():
+            raise ValueError(f"ERROR ::: Path {path} does not exist.")
+    return path

--- a/src/sadie/reference/blast.py
+++ b/src/sadie/reference/blast.py
@@ -28,8 +28,8 @@ def write_blast_db(filename: str, output_db: str) -> None:
         raise Exception(f"Make Blast DB {make_blast_db_exe} cant be found or is not executable")
     
     # Validate inpath fasta file and outpath directory
-    filename = pathing(filename)
-    output_db = pathing(output_db, new=True, overwrite=True)
+    filename = pathing(filename)  # make sure file exists
+    output_db = pathing(output_db, new=True, overwrite=True)  # makes sure parent directory exists
     
     # Blast does not allow spaces in the path; need to use a temp file/dir
     with tempfile.NamedTemporaryFile(suffix=filename.suffix) as tmp_filename_obj:


### PR DESCRIPTION
# Includes
1. Creating mirrored tmp files for makeblastdb -in & -out params
2. Add a click for direct access to makeblastdb

# Fixes
Spacing in paths issue known in Blast command line  #37 

# Example
```
sadie reference makeblastdb -i ~/Dropbox\ \(Scripps\ Research\)/repos/sadie/src/sadie/airr/data/germlines/custom/Ig/internal_data/cat/cat_V.fasta -o ~/Desktop/germlines/test_me_out3
```