### PR TITLE
fix: pandas 3.x compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.14']
+        # pandas 3.x requires Python >=3.11, so 3.10 stays on pandas 2.x
+        include:
+          - python-version: '3.10'
+            pandas-version: '2'
+          - python-version: '3.14'
+            pandas-version: '2'
+          - python-version: '3.14'
+            pandas-version: '3'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,15 +39,17 @@ jobs:
         run: |
           pip install poetry wheel
           poetry install --with dev
+      - name: Pin pandas ${{ matrix.pandas-version }}.x
+        run: poetry run pip install "pandas==${{ matrix.pandas-version }}.*"
       - name: PreCommit
-        if: matrix.python-version == '3.14'
+        if: matrix.python-version == '3.14' && matrix.pandas-version == '3'
         uses: pre-commit/action@v3.0.1
       - name: Unit Testing
         run: poetry run pytest -xsv tests/unit
       - name: Integration Testing
         run: poetry run pytest -xv tests/integration
       - name: Static Type Check
-        if: matrix.python-version == '3.14'
+        if: matrix.python-version == '3.14' && matrix.pandas-version == '3'
         run: poetry run pyright
 
   coverage:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3559,4 +3559,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "5ce8cf5a72d41ad9c2aa910b04bd9decd384ecff7277dbcfdaaa998f78a5ff9f"
+content-hash = "837f0ff98fce5e872af6a90598dd11fa1a364c0abb9b3b67389596696aea1ee5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ click = ">=8.0,<8.2"
 filetype = "^1.2.0"
 pandas = [
     { version = ">=2.0,<3.0", python = "<3.11" },
-    { version = ">=2.0", python = ">=3.11" },
+    { version = ">=2.0,<4.0", python = ">=3.11" },
 ]
 requests = "^2.32.0"
 pydantic = ">=2.0.0,<3.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,10 @@ python = ">=3.10"
 biopython = ">=1.80"
 click = ">=8.0,<8.2"
 filetype = "^1.2.0"
-pandas = ">=1.5,<3.0"
+pandas = [
+    { version = ">=2.0,<3.0", python = "<3.11" },
+    { version = ">=2.0", python = ">=3.11" },
+]
 requests = "^2.32.0"
 pydantic = ">=2.0.0,<3.0.0"
 python-Levenshtein = "^0.27.0"

--- a/src/sadie/__init__.py
+++ b/src/sadie/__init__.py
@@ -1,4 +1,16 @@
 __version__ = "0.0.0"  # Replaced by poetry-dynamic-versioning at build time
+
+import pandas as _pd
+
+# SADIE stores strings as object-dtype columns and treats missing values as float
+# NaN (the AirrTable/NumberingResults logic relies on ``isinstance(x, float)``).
+# pandas 3.0 (PDEP-14) defaults to a new StringDtype; opt back out so behavior
+# matches pandas 2.x. The option does not exist before pandas 2.1, hence the guard.
+try:
+    _pd.set_option("future.infer_string", False)
+except (KeyError, _pd.errors.OptionError):
+    pass
+
 from . import airr, numbering, receptor, reference, renumbering
 
 __all__ = ["renumbering", "receptor", "airr", "reference", "numbering"]

--- a/src/sadie/airr/airr.py
+++ b/src/sadie/airr/airr.py
@@ -26,6 +26,7 @@ from sadie.airr.airrtable import AirrTable, LinkedAirrTable
 from sadie.airr.exceptions import BadDataSet, BadIgBLASTExe, BadRequstedFileType
 from sadie.airr.igblast import GermlineData, IgBLASTN
 from sadie.reference.reference import References
+from sadie.utility.io import get_file_buffer, guess_input_compression
 
 logger = logging.getLogger("AIRR")
 warnings.filterwarnings("ignore", "Partial codon")
@@ -520,7 +521,8 @@ class Airr:
 
         # make sure it's fasta - this will consume the generator but blast has its own fasta parser
         try:
-            next(SeqIO.parse(file, "fasta"))
+            with get_file_buffer(Path(file), guess_input_compression(file)) as handle:
+                next(SeqIO.parse(handle, "fasta"))
         except Exception:
             raise BadRequstedFileType("", ["fasta"])
 
@@ -639,6 +641,14 @@ class Airr:
                         if not adapt_results[~adapt_results["liable"]].empty:
                             result.update(adapt_results[~adapt_results["liable"]])
 
+                # DataFrame.update only writes non-NA values, so a re-run can copy its
+                # liable flag onto a row while leaving region columns from the original
+                # alignment intact, leaving `liable` inconsistent with the final regions.
+                # Recompute liable from the merged regions so the column always reflects
+                # the alignment actually present (matching a fresh AirrTable verify).
+                liability_keys = ["fwr1_aa", "cdr1_aa", "fwr2_aa", "cdr2_aa", "fwr3_aa", "cdr3_aa", "fwr4_aa"]
+                result["liable"] = result[liability_keys].apply(result._check_j_gene_liability, axis=1)
+
         if self.correct_indel:
             result.correct_indel()  # type: ignore[attr-defined]
 
@@ -660,7 +670,7 @@ class Airr:
         remaining_seq = (
             result_a[["sequence", "sequence_alignment"]]
             .fillna("")
-            .apply(lambda x: x[0].replace(x[1].replace("-", ""), ""), axis=1)
+            .apply(lambda x: x.iloc[0].replace(x.iloc[1].replace("-", ""), ""), axis=1)
         )
         # and get those ids
         remaining_id = result_a["sequence_id"]

--- a/src/sadie/airr/airrtable/airrtable.py
+++ b/src/sadie/airr/airrtable/airrtable.py
@@ -285,14 +285,14 @@ class AirrTable(pd.DataFrame):
 
     @classmethod
     def _constructor_from_mgr(cls, mgr, axes):
-        """Override to prevent recursion during internal pandas operations."""
-        # Create instance with the flag set to prevent verification
-        obj = cls.__new__(cls)
-        obj._in_constructor = True
-        # Call parent constructor
-        pd.DataFrame.__init__(obj, mgr)
+        """Build from a manager without re-running __init__/_verify.
+
+        Uses the ``_from_mgr`` fast path (NDFrame.__init__) so a BlockManager is
+        never passed into ``DataFrame.__init__``; that path is deprecated in
+        pandas 2.1+ and raises in pandas 3.
+        """
+        obj = cls._from_mgr(mgr, axes=axes)
         obj._in_constructor = False
-        # Copy metadata from the original if available
         return obj
 
     @property
@@ -554,26 +554,24 @@ class AirrTable(pd.DataFrame):
                     )
 
                 # get mutation frequency rather than identity
-                self.loc[:, f"v_mutation{suffix}"] = self[f"v_identity{suffix}"].apply(lambda x: (1 - x))
-                # self.loc[:, f"v_identity{suffix}"] = self[f"v_identity{suffix}"].apply(lambda x: x / 100)
+                self[f"v_mutation{suffix}"] = self[f"v_identity{suffix}"].apply(lambda x: (1 - x))
+                # self[f"v_identity{suffix}"] = self[f"v_identity{suffix}"].apply(lambda x: x / 100)
 
                 # then get a percentage for AA by computing levenshtein
-                self.loc[:, f"v_mutation_aa{suffix}"] = self[
+                self[f"v_mutation_aa{suffix}"] = self[
                     [f"v_sequence_alignment_aa{suffix}", f"v_germline_alignment_aa{suffix}"]
                 ].apply(lambda x: self._get_aa_distance(x), axis=1)
 
                 # do the same for D and J gene segment portions
-                self.loc[:, f"d_mutation{suffix}"] = self[f"d_identity{suffix}"].apply(
-                    lambda x: (1 - x) if x else np.nan
-                )
-                # self.loc[:, f"d_identity{suffix}"] = self[f"d_identity{suffix}"].apply(lambda x: x / 100)
+                self[f"d_mutation{suffix}"] = self[f"d_identity{suffix}"].apply(lambda x: (1 - x) if x else np.nan)
+                # self[f"d_identity{suffix}"] = self[f"d_identity{suffix}"].apply(lambda x: x / 100)
 
-                self.loc[:, f"d_mutation_aa{suffix}"] = self[
+                self[f"d_mutation_aa{suffix}"] = self[
                     [f"d_sequence_alignment_aa{suffix}", f"d_germline_alignment_aa{suffix}"]
                 ].apply(lambda x: self._get_aa_distance(x), axis=1)
-                self.loc[:, f"j_mutation{suffix}"] = self[f"j_identity{suffix}"].apply(lambda x: (1 - x))
-                # self.loc[:, f"j_identity{suffix}"] = self[f"j_identity{suffix}"].apply(lambda x: x / 100)
-                self.loc[:, f"j_mutation_aa{suffix}"] = self[
+                self[f"j_mutation{suffix}"] = self[f"j_identity{suffix}"].apply(lambda x: (1 - x))
+                # self[f"j_identity{suffix}"] = self[f"j_identity{suffix}"].apply(lambda x: x / 100)
+                self[f"j_mutation_aa{suffix}"] = self[
                     [f"j_sequence_alignment_aa{suffix}", f"j_germline_alignment_aa{suffix}"]
                 ].apply(lambda x: self._get_aa_distance(x), axis=1)
 
@@ -590,21 +588,21 @@ class AirrTable(pd.DataFrame):
                     )
 
             # get mutation frequency rather than identity
-            self.loc[:, "v_mutation"] = self["v_identity"].apply(lambda x: (1 - x))
+            self["v_mutation"] = self["v_identity"].apply(lambda x: (1 - x))
 
             # then get a percentage for AA by computing levenshtein
-            self.loc[:, "v_mutation_aa"] = self[["v_sequence_alignment_aa", "v_germline_alignment_aa"]].apply(
+            self["v_mutation_aa"] = self[["v_sequence_alignment_aa", "v_germline_alignment_aa"]].apply(
                 lambda x: self._get_aa_distance(x), axis=1
             )
 
             # do the same for D and J gene segment portions
-            self.loc[:, "d_mutation"] = self["d_identity"].apply(lambda x: (1 - x) if x else np.nan)
-            self.loc[:, "d_mutation_aa"] = self[["d_sequence_alignment_aa", "d_germline_alignment_aa"]].apply(
+            self["d_mutation"] = self["d_identity"].apply(lambda x: (1 - x) if x else np.nan)
+            self["d_mutation_aa"] = self[["d_sequence_alignment_aa", "d_germline_alignment_aa"]].apply(
                 lambda x: self._get_aa_distance(x), axis=1
             )
-            self.loc[:, "j_mutation"] = self["j_identity"].apply(lambda x: (1 - x))
-            # self.loc[:, "j_identity"] = self["j_identity"].apply(lambda x: x / 100)
-            self.loc[:, "j_mutation_aa"] = self[["j_sequence_alignment_aa", "j_germline_alignment_aa"]].apply(
+            self["j_mutation"] = self["j_identity"].apply(lambda x: (1 - x))
+            # self["j_identity"] = self["j_identity"].apply(lambda x: x / 100)
+            self["j_mutation_aa"] = self[["j_sequence_alignment_aa", "j_germline_alignment_aa"]].apply(
                 lambda x: self._get_aa_distance(x), axis=1
             )
         self._verified = True
@@ -672,13 +670,12 @@ class AirrTable(pd.DataFrame):
         bool
            if the entry is liable or not based
         """
-        fw1 = X.iloc[0]
-        cdr1 = X.iloc[1]
-        fw2 = X.iloc[2]
-        cdr2 = X.iloc[3]
-        fw3 = X.iloc[4]
-        cdr3 = X.iloc[5]
-        fw4 = X.iloc[6]
+        # Canonicalize missing values to float('nan') so liability is computed identically
+        # regardless of how the backend stores NA. pandas 2 reads feather NA as None while
+        # pandas 3 reads it as float('nan'); since the checks below use isinstance(i, float)
+        # as the missing-value test, an unnormalized None and NaN for the same stored row
+        # would otherwise classify differently across pandas versions.
+        fw1, cdr1, fw2, cdr2, fw3, cdr3, fw4 = (float("nan") if pd.isna(i) else i for i in X.iloc[:7])
         isna = [isinstance(i, float) for i in [fw1, cdr1, fw2, cdr2, fw3, cdr3, fw4]]
         # if they are all nan:
         if all(isna):
@@ -730,7 +727,7 @@ class AirrTable(pd.DataFrame):
             # get indels in sequence_germline_alignment_aa that were not accounted for in the total alignment
             indel_indexes = _get_indel_index(field_1, field_2)
             logger.info(f"Have {len(indel_indexes)} possible indels that are not in amino acid germline alignment")
-            self.loc[:, f"{field_2}_corrected"] = False
+            self[f"{field_2}_corrected"] = False
             if not indel_indexes.empty:
                 # Pass self through top level dataframe to remove validation checks when using apply.
                 correction_alignments = pd.DataFrame(self.loc[indel_indexes, :]).apply(

--- a/src/sadie/airr/airrtable/airrtable.py
+++ b/src/sadie/airr/airrtable/airrtable.py
@@ -291,7 +291,7 @@ class AirrTable(pd.DataFrame):
         never passed into ``DataFrame.__init__``; that path is deprecated in
         pandas 2.1+ and raises in pandas 3.
         """
-        obj = cls._from_mgr(mgr, axes=axes)
+        obj = getattr(cls, "_from_mgr")(mgr, axes=axes)
         obj._in_constructor = False
         return obj
 

--- a/src/sadie/airr/methods.py
+++ b/src/sadie/airr/methods.py
@@ -351,9 +351,9 @@ def run_mutational_analysis(
         lookup_specific = lookup_dataframe[[germ_tag, mat_tag]]
 
         # mutation array are all the mutations in a list
-        mutation_array = lookup_specific[lookup_specific.apply(lambda x: x[0] != x[1] and x[0] != "X", axis=1)].apply(
-            lambda x: x[0] + x.name + x[1], axis=1
-        )
+        mutation_array = lookup_specific[
+            lookup_specific.apply(lambda x: x.iloc[0] != x.iloc[1] and x.iloc[0] != "X", axis=1)
+        ].apply(lambda x: x.iloc[0] + x.name + x.iloc[1], axis=1)
         if mutation_array.empty:
             mutation_array = []  # type: ignore[assignment]
         else:

--- a/src/sadie/reference/reference.py
+++ b/src/sadie/reference/reference.py
@@ -321,7 +321,7 @@ class References:
         concat_df_groupby_name = concat_df.groupby("name")
 
         # within names, check how many species are there
-        chimeric_gb = concat_df_groupby_name.apply(lambda x: len(x["common"].unique()) > 1)
+        chimeric_gb = concat_df_groupby_name["common"].apply(lambda x: len(x.unique()) > 1)
 
         list_of_chimera: List[str] = chimeric_gb[chimeric_gb].index.to_list()
         logger.info(f"{list_of_chimera} are chimeric")

--- a/src/sadie/reference/yaml.py
+++ b/src/sadie/reference/yaml.py
@@ -22,7 +22,8 @@ class YamlRef:
         if not filepath:
             filepath = Path(__file__).parent.joinpath("data/reference.yml")
         self.ref_path = filepath
-        self.yaml = load(open(self.ref_path), Loader=Loader)
+        with open(self.ref_path) as ref_handle:
+            self.yaml = load(ref_handle, Loader=Loader)
         self.yaml_df = self._normalize_and_verify_yaml()
 
     def get_names(self) -> Set[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,8 @@ class AirrSequences:
         self.fastq_inputs = self.base_datadir / "fastq_inputs/"
         self.airr_table_inputs = self.base_datadir / "airr_tables/"
         self.abi_inputs = self.base_datadir / "ab1_files/"
-        self.single_seqs_json = json.load(open(self.base_datadir / "single-sequences.json"))
+        with open(self.base_datadir / "single-sequences.json") as single_seqs_handle:
+            self.single_seqs_json = json.load(single_seqs_handle)
 
     def get_pg9_heavy_fasta(self) -> Path:
         """get the file path for PG9 heavy chain fasta"""

--- a/tests/integration/airr/test_airr_intergration.py
+++ b/tests/integration/airr/test_airr_intergration.py
@@ -109,7 +109,7 @@ def _make_sadie_comparable(df):
     # Just get compare keys
     df = pd.DataFrame(df)
     df = df[compare_key].drop(ignore, axis=1)
-    df.loc[:, starts_and_ends] = df[starts_and_ends].astype("Int64")
+    df[starts_and_ends] = df[starts_and_ends].astype("Int64")
     # Just get the gene top call IGHV1-2*01 -> IGHV1-2
     df.insert(
         df.columns.get_loc("v_call_top"),
@@ -201,7 +201,7 @@ def _make_imgt_comparable(df: pd.DataFrame) -> pd.DataFrame:
     df = df.drop(ignore, axis=1)
 
     # Convert the integer types
-    df.loc[:, starts_and_ends] = df[starts_and_ends].astype("Int64")
+    df[starts_and_ends] = df[starts_and_ends].astype("Int64")
     return df
 
 

--- a/tests/integration/reference/test_reference_integration.py
+++ b/tests/integration/reference/test_reference_integration.py
@@ -143,7 +143,7 @@ def _test_auxilary_file_structure(tmpdir: Path, fixture_setup: SadieFixture) -> 
         df = pd.read_csv(
             file,
             skip_blank_lines=True,
-            delim_whitespace=True,
+            sep=r"\s+",
             skiprows=2,
             header=None,
             names=["gene", "reading_frame", "segment", "cdr3_end", "left_over"],


### PR DESCRIPTION
Replace deprecated .loc setitem and BlockManager __init__ path, opt out of PDEP-14 string dtype, normalize NA handling, and add a 3.14 + pandas 3 CI leg.