### PR TITLE
Parallelize clustering distance calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 .installed.cfg
 *.egg
 .pytest_cache
+.hypothesis/
 
 pip-log.txt
 .vscode

--- a/poetry.lock
+++ b/poetry.lock
@@ -658,6 +658,100 @@ doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
+name = "hypothesis"
+version = "6.165.0"
+description = "The property-based testing library for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "hypothesis-6.165.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dda3707dfdfdc1397b7489ecb81534f47f22f98d468c51c92d591d6967c58b29"},
+    {file = "hypothesis-6.165.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a384468744915435a25a9f2dcd0a74e9f78f8d56cb51f5ea1c1c4973bd40bd5b"},
+    {file = "hypothesis-6.165.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d65562b9866a5a4be4c731bd4018152861997675b92ed6d0f29e925999928f9a"},
+    {file = "hypothesis-6.165.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b402560b0463e643170d904a5987f61bc388718f7b48d4521b7a5b22e6a27019"},
+    {file = "hypothesis-6.165.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1e134b573c18fb7e79f915ccad3585f81c0b92ff7cf89f6c0b0d966a5ac5156"},
+    {file = "hypothesis-6.165.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:22d3b846796593117a1227b6d9e8c0c1269ce6327fa6345fb50f24a038e1a0c1"},
+    {file = "hypothesis-6.165.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:47d419899477ed35704d4f90f82aadbaa50080d7d0ff33db6727bbc4b1c3956d"},
+    {file = "hypothesis-6.165.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:71721d9de23b60f5436a1b8b8fddccd6df606efbb406f36254195089974518ee"},
+    {file = "hypothesis-6.165.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:584734f6380f1965498bff2f72af307c182b3398a9c4e1b2f31e43dd1aa9c922"},
+    {file = "hypothesis-6.165.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:61d99c493f759809e64dbe544a47948537460c9f03f916d66291bb63965fc91a"},
+    {file = "hypothesis-6.165.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:68629657d49b7dba3f061d0224441df068c0c03e7a17efc278782f637d810db7"},
+    {file = "hypothesis-6.165.0-cp310-abi3-win32.whl", hash = "sha256:90633ec15635385723d29a1e9b6fe8f63e17b33641353c6b58fc7d277672ef29"},
+    {file = "hypothesis-6.165.0-cp310-abi3-win_amd64.whl", hash = "sha256:bab53228c59978c74c87dba27db4656feaf991f20db5242ea263531477227247"},
+    {file = "hypothesis-6.165.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3eb93f9b01ac3093a6222ac1abbf2e38a467f3d9d58ba0ba7b7edd5c6dbd4a04"},
+    {file = "hypothesis-6.165.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9577cef884fba9c7dd53c5621ac7998a36c0ab9305e6e144ea68888450a617e0"},
+    {file = "hypothesis-6.165.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d133114ff723ab9cd1ae72407ae1174061d78a25992196ab54e2e7a8fd7f3e8"},
+    {file = "hypothesis-6.165.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23764c6b64b60cb160ddc2aaefccb505abe234d2a82fc30ea75d28e94ecab44a"},
+    {file = "hypothesis-6.165.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b37a9736395c2bc6a6f6ad42abb7bcaf935f5926ff9f688218eb05547d92927d"},
+    {file = "hypothesis-6.165.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:33b0f9ad5e9c86b80568b58af3710fdfd838a656d3500a050216238733235752"},
+    {file = "hypothesis-6.165.0-cp310-cp310-win_amd64.whl", hash = "sha256:077756e2e648292aa5e181b1556eb4744720f7829aa7a810585fb90b543cc6fa"},
+    {file = "hypothesis-6.165.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d71abdac3786725b3af5657024b00f8cfc690e56a8ba5020fd693f2d4339bcc6"},
+    {file = "hypothesis-6.165.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddf924a80fc9b8cbd3bf31282821111be30e0ea5262c755fff861b827c9667d7"},
+    {file = "hypothesis-6.165.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4acd5f4e33afe297262bc8ae017d800f76fbeb6c8ec6fcb8885f210781fe826"},
+    {file = "hypothesis-6.165.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d4b41dfc0e43533ef8e1525cd5084f880d633d4dec512bb63d3d33766bad288"},
+    {file = "hypothesis-6.165.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:121ca3e24c74bbed3cb9841ef37d25535fa32ec4708a252ef1a76516d35ccda8"},
+    {file = "hypothesis-6.165.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8f7a440ef9f8319d26998e89ee83474ce9accb34eca4321e480ad3d2fbd74622"},
+    {file = "hypothesis-6.165.0-cp311-cp311-win_amd64.whl", hash = "sha256:d6d634e0e2ae2e367ea54180c0c654bd0ca756204cdec2473e01ebab2eaad793"},
+    {file = "hypothesis-6.165.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6942d6a0002092c9a1166915d26a3257c17da4b8c76859c9841b84a21a572262"},
+    {file = "hypothesis-6.165.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:20a17a11eeb3816b3d4c9576d4d9b44a985bf062ae232d0fad9a2e5c16b35a6b"},
+    {file = "hypothesis-6.165.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2d5018013480fe207408e0d7c04244c46a7113c1c2aef779cbe17e1f8750988"},
+    {file = "hypothesis-6.165.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504feb1f67bd1e6c83d42982f9f80a6d11acb164cc11519d4abf2e7479394be2"},
+    {file = "hypothesis-6.165.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eff69d0c3ad00fe82f06420c8d13c33b86db24636c96ac457cbd9a5a588f6e88"},
+    {file = "hypothesis-6.165.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db118ef2c469fe607ac617a15ccc8bc0e05f27b866c1d923c963d9edd3e4b7e1"},
+    {file = "hypothesis-6.165.0-cp312-cp312-win_amd64.whl", hash = "sha256:f16f8fd1ca5d1a080a360bb37eee73f3fecf3ddabdcec979ae01b76ed895e777"},
+    {file = "hypothesis-6.165.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:82385ff61d309b77097580e7200dc3e038f5eb78d3fe1a4aa0d110e5f1afa9df"},
+    {file = "hypothesis-6.165.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2e7b277f56786ec0730cd3e428ea3611b59e3ecae3382553f3fea958e8c2c25f"},
+    {file = "hypothesis-6.165.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c73d3d4e57a00122a2657ae400b8d066fd0cfa1621c6aa3a6b38dd4b4c268035"},
+    {file = "hypothesis-6.165.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89b41b1daa93c9e544cdad636ec87d4a45169d1922c6aff80fa282cd1edeeb74"},
+    {file = "hypothesis-6.165.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b2fef387ec63e60c85db6c4fc95b07a6b7f35c971381997c862d309af9e1e4b"},
+    {file = "hypothesis-6.165.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c681bdf0036ba7923b7c4225937a48e12db7029a286b51ddc03d9b08afe2f040"},
+    {file = "hypothesis-6.165.0-cp313-cp313-win_amd64.whl", hash = "sha256:29edc5a08334985cea55afe6ab564c147e4b804179265eb303c9ed8e494c211b"},
+    {file = "hypothesis-6.165.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6536572500e926ec8128069fda8bbcd13019484e0d5c1b4a82b6ef50417bcfbe"},
+    {file = "hypothesis-6.165.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d86c82a7796d124643d146eef00d873d336d1792a682096358bfee82dde34879"},
+    {file = "hypothesis-6.165.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b646658e06b72b2bd2396ffe7a08a0edcfa799f649db22e1d59cc8bd5d174e6"},
+    {file = "hypothesis-6.165.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e0fb8c29ad35fefa25f38c0bbc1b2eee28d1e4a796a977491445b05d11cb1ae"},
+    {file = "hypothesis-6.165.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a998176a8cf1b1914c5cf8beef0b74d0065482aa2a4d0c708e63216245d968c7"},
+    {file = "hypothesis-6.165.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:510518cb4259916685151aa41c44a3999534c35eee921dcfbc4ea4e4631bd6d2"},
+    {file = "hypothesis-6.165.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:1f786c76577ec0639390baf0b4c12491fa909131e41de76078a4a886ccd40661"},
+    {file = "hypothesis-6.165.0-cp314-cp314-win_amd64.whl", hash = "sha256:0bbc39067ba06514fc0c934c34863492403ffc708a07d6a506b9460058550127"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:38222e75db0f348c8ddaab10903fc3971846f11363e64efdb4794f34aed6494f"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:01c485be9970a40935b2d2f277d751d60aaa910e4dc5ec337828e80c9c8dfdc8"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bcb354b9bfc7dcf5fbcb559cd5b3f48e0d92a4f1f6e5fbcf9fbc8cc82e51e61"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51dbf9192af532f9081c90f00afb0a7684da5543ccae8ab9507da269b6702ccf"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:70dd766e80e575580e635d6661f945ef07055e66075a93fd489d53611cb5a7a1"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5e811db36037576b277d8fc390d3fcb94d7924ec861d05adb0cdfd8e3ea86822"},
+    {file = "hypothesis-6.165.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7a14b7905e4aad404c820bd01f8a1272042123233edf04149b847db2c5076584"},
+    {file = "hypothesis-6.165.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1c228b2fdd018e56a50c5a18e003fa8d139374321f2e79739c19ffcc1138b6b3"},
+    {file = "hypothesis-6.165.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:66376231b678675abfd670a6df1bb59c4e760c894411d4333dd48126072fc0a8"},
+    {file = "hypothesis-6.165.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b407d4441af3f0c807a0904ec9d4c7cb71a5612961f2a6a23475eeb34329392d"},
+    {file = "hypothesis-6.165.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06970b389b442740bb6aece39bda3c925d7ac5c23d9bcdcae9f5b2c6aa3002b0"},
+    {file = "hypothesis-6.165.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1748c1e6db507023cda4bd21d7706ad17b9339fb99232676e0ddbb213ff976e3"},
+    {file = "hypothesis-6.165.0.tar.gz", hash = "sha256:b54e86cb1d7d049eb934e7843f179889252263b24290ebd38549466c9c9351d9"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.0", markers = "python_full_version < \"3.11.0\""}
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=20.8b0)", "click (>=7.0)", "crosshair-tool (>=0.0.109)", "django (>=5.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.30)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.21.6)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2026.3) ; sys_platform == \"emscripten\" or sys_platform == \"win32\"", "watchdog (>=4.0.0)"]
+cli = ["black (>=20.8b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+crosshair = ["crosshair-tool (>=0.0.109)", "hypothesis-crosshair (>=0.0.30)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=5.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=20.8b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.21.6)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+watchdog = ["watchdog (>=4.0.0)"]
+zoneinfo = ["tzdata (>=2026.3) ; sys_platform == \"emscripten\" or sys_platform == \"win32\""]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 description = "File identification library for Python"
@@ -3123,6 +3217,18 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -3559,4 +3665,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "1b1f64d850476d83fe9d7a127409e4f323fc46c1f6ea6249c23d2af1fac96124"
+content-hash = "2992d68b769ea394aac1d0db3ce5a7b35fb09a49cf962b590bf3e311095bf0db"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3559,4 +3559,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "837f0ff98fce5e872af6a90598dd11fa1a364c0abb9b3b67389596696aea1ee5"
+content-hash = "1b1f64d850476d83fe9d7a127409e4f323fc46c1f6ea6249c23d2af1fac96124"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ rich = "^14.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+hypothesis = ">=6.100,<7.0"
 flake8 = "^7.0.0"
 pre-commit = "^3.6.0"
 coverage = "^7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pandas = [
 requests = "^2.32.0"
 pydantic = ">=2.0.0,<3.0.0"
 python-Levenshtein = "^0.27.0"
+rapidfuzz = ">=3.9,<4.0"
 pyarrow = "*"
 numpy = [
     { version = "*", python = "<3.11" },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,9 @@
 [pytest]
 addopts = -x
 testpaths = tests
-norecursedirs = antibody_objects_old .git __pycache__ .eggs *.egg-info dist build docs
+markers =
+    greedy: opt-in, multi-hour differential stress tests
+norecursedirs = antibody_objects_old .git .hypothesis __pycache__ .eggs *.egg-info dist build docs
 log_format = %(asctime)s.%(msecs)03d %(levelname)s: %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s: %(message)s

--- a/src/sadie/cluster/cluster.py
+++ b/src/sadie/cluster/cluster.py
@@ -6,9 +6,12 @@ from typing import Any, Iterable, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+from Levenshtein import distance as lev_distance
 from rapidfuzz.distance import Levenshtein
 from rapidfuzz.process import cdist
 from sklearn.cluster import AgglomerativeClustering
+from sklearn.metrics import pairwise_distances
+from sklearn.utils.validation import check_array
 
 from sadie.airr import AirrTable, LinkedAirrTable
 
@@ -116,7 +119,68 @@ class Cluster:
             _lookup = self.lookup
         df_lookup = df[_lookup].to_dict(orient="index")
 
-        rows = list(df_lookup.values())
+        def legacy_distance() -> Any:
+            def calc_lev(x: Any, y: Any) -> float:
+                dist = sum(
+                    lev_distance(str(df_lookup[x[0]][metric]), str(df_lookup[y[0]][metric])) for metric in self.lookup
+                )
+                if self.pad_somatic and x[0] != y[0]:
+                    if len(self.pad_somatic_values) == 2:
+                        dist -= len(
+                            np.intersect1d(
+                                df_lookup[x[0]][self.pad_somatic_values[0]],
+                                df_lookup[y[0]][self.pad_somatic_values[0]],
+                            )
+                        ) + len(
+                            np.intersect1d(
+                                df_lookup[x[0]][self.pad_somatic_values[1]],
+                                df_lookup[y[0]][self.pad_somatic_values[1]],
+                            )
+                        )
+                    else:
+                        dist -= len(
+                            np.intersect1d(
+                                df_lookup[x[0]][self.pad_somatic_values[0]],
+                                df_lookup[y[0]][self.pad_somatic_values[0]],
+                            )
+                        )
+                return max(dist, 0)
+
+            indexes = np.array(df.index).reshape(-1, 1)
+            return pairwise_distances(indexes, metric=calc_lev, n_jobs=-1)
+
+        stable_types = (str, bytes, bool, int, float, complex, type(None))
+        use_fast_path = len(df) > 0 and all(
+            type(index) in stable_types or index is pd.NA or index is pd.NaT for index in df.index
+        )
+        if self.pad_somatic and len(self.pad_somatic_values) not in (1, 2):
+            use_fast_path = False
+        if use_fast_path:
+            use_fast_path = all(
+                type(row[metric]) in stable_types or row[metric] is pd.NA or row[metric] is pd.NaT
+                for row in df_lookup.values()
+                for metric in self.lookup
+            )
+        if use_fast_path and self.pad_somatic:
+            use_fast_path = all(
+                type(mutations) in (list, tuple, np.ndarray)
+                and not (type(mutations) is np.ndarray and mutations.ndim != 1)
+                and all(type(mutation) in (str, np.str_) and "\0" not in mutation for mutation in mutations)
+                for row in df_lookup.values()
+                for mutations in (row[metric] for metric in self.pad_somatic_values)
+            )
+        if not use_fast_path:
+            return legacy_distance()
+
+        index_values = np.array(df.index)
+        check_array(
+            index_values.reshape(-1, 1),
+            dtype=None,
+            ensure_2d=False,
+            estimator="check_pairwise_arrays",
+        )
+
+        rows = [df_lookup[index] for index in index_values]
         workers = -1 if len(df) >= _THREAD_MIN_ROWS else 1
         distances = np.zeros((len(df), len(df)), dtype=np.float64)
         for metric in self.lookup:
@@ -133,8 +197,7 @@ class Cluster:
             for metric in self.pad_somatic_values:
                 rows_by_mutation: dict[str, list[int]] = {}
                 for row_index, row in enumerate(rows):
-                    mutations: Iterable[str] = row[metric]
-                    for mutation in set(mutations):
+                    for mutation in set(row[metric]):
                         rows_by_mutation.setdefault(mutation, []).append(row_index)
                 for row_indexes in rows_by_mutation.values():
                     distances[np.ix_(row_indexes, row_indexes)] -= 1

--- a/src/sadie/cluster/cluster.py
+++ b/src/sadie/cluster/cluster.py
@@ -8,12 +8,17 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from Levenshtein import distance as lev_distance
+from rapidfuzz.distance import Levenshtein
+from rapidfuzz.process import cdist
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.metrics import pairwise_distances
 
 from sadie.airr import AirrTable, LinkedAirrTable
 
 logger = logging.getLogger("Cluster")
+
+# ponytail: measured thread crossover; expose tuning only if other hardware disagrees.
+_THREAD_MIN_ROWS = 150
 
 
 class Cluster:
@@ -114,6 +119,20 @@ class Cluster:
             _lookup = self.lookup
         df_lookup = df[_lookup].to_dict(orient="index")
 
+        if not self.pad_somatic:
+            workers = -1 if len(df) >= _THREAD_MIN_ROWS else 1
+            distances = np.zeros((len(df), len(df)), dtype=np.float64)
+            for metric in self.lookup:
+                values = [str(row[metric]) for row in df_lookup.values()]
+                distances += cdist(
+                    values,
+                    values,
+                    scorer=Levenshtein.distance,
+                    workers=workers,
+                    dtype=np.int32,
+                )
+            return distances
+
         def calc_lev(x: npt.ArrayLike, y: npt.ArrayLike) -> float:
             dist = 0
             for metric in self.lookup:
@@ -185,7 +204,5 @@ class Cluster:
                     raise ValueError("groupby must be a string or a list/tuple of strings")
                 sub_df["cluster"] = labels
                 cluster_catcher.append(sub_df)
-            self.airrtable = pd.concat(cluster_catcher)
-        if self._type == "unlinked":
-            return AirrTable(self.airrtable, key_column=self.key_column)
-        return LinkedAirrTable(self.airrtable, key_column=self.key_column)
+            self.airrtable = pd.concat(cluster_catcher).__finalize__(self.airrtable)
+        return self.airrtable

--- a/src/sadie/cluster/cluster.py
+++ b/src/sadie/cluster/cluster.py
@@ -17,7 +17,7 @@ from sadie.airr import AirrTable, LinkedAirrTable
 
 logger = logging.getLogger("Cluster")
 
-# ponytail: measured thread crossover; expose tuning only if other hardware disagrees.
+# Measured threading crossover; keep private unless other hardware disagrees.
 _THREAD_MIN_ROWS = 150
 
 

--- a/src/sadie/cluster/cluster.py
+++ b/src/sadie/cluster/cluster.py
@@ -5,13 +5,10 @@ import re
 from typing import Any, Iterable, List, Optional, Union
 
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
-from Levenshtein import distance as lev_distance
 from rapidfuzz.distance import Levenshtein
 from rapidfuzz.process import cdist
 from sklearn.cluster import AgglomerativeClustering
-from sklearn.metrics import pairwise_distances
 
 from sadie.airr import AirrTable, LinkedAirrTable
 
@@ -119,42 +116,30 @@ class Cluster:
             _lookup = self.lookup
         df_lookup = df[_lookup].to_dict(orient="index")
 
-        if not self.pad_somatic:
-            workers = -1 if len(df) >= _THREAD_MIN_ROWS else 1
-            distances = np.zeros((len(df), len(df)), dtype=np.float64)
-            for metric in self.lookup:
-                values = [str(row[metric]) for row in df_lookup.values()]
-                distances += cdist(
-                    values,
-                    values,
-                    scorer=Levenshtein.distance,
-                    workers=workers,
-                    dtype=np.int32,
-                )
-            return distances
+        rows = list(df_lookup.values())
+        workers = -1 if len(df) >= _THREAD_MIN_ROWS else 1
+        distances = np.zeros((len(df), len(df)), dtype=np.float64)
+        for metric in self.lookup:
+            values = [str(row[metric]) for row in rows]
+            distances += cdist(
+                values,
+                values,
+                scorer=Levenshtein.distance,
+                workers=workers,
+                dtype=np.int32,
+            )
 
-        def calc_lev(x: npt.ArrayLike, y: npt.ArrayLike) -> float:
-            dist = 0
-            for metric in self.lookup:
-                dist += lev_distance(str(df_lookup[x[0]][metric]), str(df_lookup[y[0]][metric]))  # type: ignore[index]
-            if self.pad_somatic and x[0] != y[0]:  # type: ignore[index]
-                if len(self.pad_somatic_values) == 2:
-                    _mutations_1_heavy = df_lookup[x[0]][self.pad_somatic_values[0]]  # type: ignore[index]
-                    _mutations_2_heavy = df_lookup[y[0]][self.pad_somatic_values[0]]  # type: ignore[index]
-                    _mutations_1_light = df_lookup[x[0]][self.pad_somatic_values[1]]  # type: ignore[index]
-                    _mutations_2_light = df_lookup[y[0]][self.pad_somatic_values[1]]  # type: ignore[index]
-                    subtract_heavy = len(np.intersect1d(_mutations_1_heavy, _mutations_2_heavy))
-                    subtract_light = len(np.intersect1d(_mutations_1_light, _mutations_2_light))
-                    subtract_all = subtract_heavy + subtract_light
-                else:
-                    _mutations_1 = df_lookup[x[0]][self.pad_somatic_values[0]]  # type: ignore[index]
-                    _mutations_2 = df_lookup[y[0]][self.pad_somatic_values[0]]  # type: ignore[index]
-                    subtract_all = len(np.intersect1d(_mutations_1, _mutations_2))
-                dist -= subtract_all
-            return max(dist, 0)
-
-        X: npt.ArrayLike = np.array(df.index).reshape(-1, 1)
-        return pairwise_distances(X, metric=calc_lev, n_jobs=-1)
+        if self.pad_somatic:
+            for metric in self.pad_somatic_values:
+                rows_by_mutation: dict[str, list[int]] = {}
+                for row_index, row in enumerate(rows):
+                    mutations: Iterable[str] = row[metric]
+                    for mutation in set(mutations):
+                        rows_by_mutation.setdefault(mutation, []).append(row_index)
+                for row_indexes in rows_by_mutation.values():
+                    distances[np.ix_(row_indexes, row_indexes)] -= 1
+            np.maximum(distances, 0, out=distances)
+        return distances
 
     def cluster(self, distance_threshold: int = 3) -> Union[AirrTable, LinkedAirrTable]:
         """Cluster the data.
@@ -204,5 +189,7 @@ class Cluster:
                     raise ValueError("groupby must be a string or a list/tuple of strings")
                 sub_df["cluster"] = labels
                 cluster_catcher.append(sub_df)
-            self.airrtable = pd.concat(cluster_catcher).__finalize__(self.airrtable)
-        return self.airrtable
+            self.airrtable = pd.concat(cluster_catcher)
+        if self._type == "unlinked":
+            return AirrTable(self.airrtable, key_column=self.key_column)
+        return LinkedAirrTable(self.airrtable, key_column=self.key_column)

--- a/tests/unit/cluster/test_cluster.py
+++ b/tests/unit/cluster/test_cluster.py
@@ -1,8 +1,58 @@
+from unittest.mock import patch
+
+import numpy as np
 import pandas as pd
+from Levenshtein import distance as lev_distance
 
 from sadie.airr import AirrTable, LinkedAirrTable
 from sadie.cluster import Cluster
 from tests.conftest import SadieFixture
+
+
+def test_threaded_distance_matches_existing_value_normalization():
+    cluster = Cluster(AirrTable(pd.DataFrame({"cdr1_aa": ["AAA"]})), lookup=["cdr1_aa"])
+    values = (["AAA", "AAB", None, np.nan, pd.NA, 123, "Å"] * 22)[:151]
+    df = pd.DataFrame({"cdr1_aa": values}, index=np.arange(10, 312, 2), dtype=object)
+    lookup = df[["cdr1_aa"]].to_dict(orient="index")
+    rows = list(lookup.values())
+    expected = np.array(
+        [[lev_distance(str(left["cdr1_aa"]), str(right["cdr1_aa"])) for right in rows] for left in rows],
+        dtype=np.float64,
+    )
+
+    result = cluster._get_distance_df(df)
+
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.float64
+    np.testing.assert_array_equal(result, result.T)
+    np.testing.assert_array_equal(np.diag(result), np.zeros(len(df)))
+
+
+def test_linked_cluster_preserves_exact_output_without_reconstruction(fixture_setup: SadieFixture):
+    ids = ["VRC26.05", "PCT64-18B", "VRC26.06", "PCT64-18C", "VRC26.08", "PCT64-18D"]
+    source = pd.read_feather(fixture_setup.get_catnap_joined_with_mutational_analysis())
+    linked = LinkedAirrTable(source.set_index("cellid").loc[ids].reset_index(), key_column="cellid")
+    expected = pd.DataFrame(linked).loc[[1, 3, 5, 0, 2, 4]].copy()
+    expected["cluster"] = [
+        "IGHV3-15*01_IGKV3-20*01_1",
+        "IGHV3-15*01_IGKV3-20*01_0",
+        "IGHV3-15*01_IGKV3-20*01_0",
+        "IGHV3-30*03_IGLV1-51*02_2",
+        "IGHV3-30*03_IGLV1-51*02_1",
+        "IGHV3-30*03_IGLV1-51*02_0",
+    ]
+    cluster = Cluster(linked, groupby=["v_call_top_heavy", "v_call_top_light"])
+
+    with patch.object(LinkedAirrTable, "__init__", side_effect=AssertionError("unexpected reconstruction")):
+        result = cluster.cluster(10)
+
+    pd.testing.assert_frame_equal(pd.DataFrame(result), expected)
+    assert result is cluster.airrtable
+    assert isinstance(result, LinkedAirrTable)
+    assert result.key_column == "cellid"
+    assert result.suffixes == ["_heavy", "_light"]
+    assert result.verified
+    assert "cluster" not in linked.columns
 
 
 def test_cluster(heavy_catnap_airrtable, light_catnap_airrtable):

--- a/tests/unit/cluster/test_cluster.py
+++ b/tests/unit/cluster/test_cluster.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 from Levenshtein import distance as lev_distance
+from rapidfuzz.process import cdist as rapidfuzz_cdist
 
 from sadie.airr import AirrTable, LinkedAirrTable
 from sadie.cluster import Cluster
@@ -28,7 +29,75 @@ def test_threaded_distance_matches_existing_value_normalization():
     np.testing.assert_array_equal(np.diag(result), np.zeros(len(df)))
 
 
-def test_linked_cluster_preserves_exact_output_without_reconstruction(fixture_setup: SadieFixture):
+def test_threaded_somatic_distance_matches_legacy_padding():
+    values = (["AAA", "AAB", None, np.nan, pd.NA, 123, "Å"] * 22)[:151]
+    mutations = (
+        [
+            np.array(["A1T", "A1T", "C94G"], dtype=object),
+            ["A1T", "G93C"],
+            [],
+            np.array(["G93C", "T120A"], dtype=object),
+            ["C94G"],
+            ["Å93B"],
+            ["X2Y", "T120A"],
+        ]
+        * 22
+    )[:151]
+    source = pd.DataFrame({"cdr1_aa": values, "mutations": mutations}, dtype=object)
+
+    for include_only_v_gene in (False, True):
+        df = source.copy(deep=True)
+        cluster = Cluster(
+            AirrTable(df.iloc[:1].copy()),
+            lookup=["cdr1_aa"],
+            pad_somatic=True,
+            include_only_v_gene=include_only_v_gene,
+        )
+        with patch("sadie.cluster.cluster.cdist", wraps=rapidfuzz_cdist) as cdist_spy:
+            result = cluster._get_distance_df(df)
+        rows = list(df[["cdr1_aa", "mutations"]].to_dict(orient="index").values())
+        expected = np.array(
+            [
+                [
+                    max(
+                        lev_distance(str(left["cdr1_aa"]), str(right["cdr1_aa"]))
+                        - len(np.intersect1d(left["mutations"], right["mutations"])),
+                        0,
+                    )
+                    for right in rows
+                ]
+                for left in rows
+            ],
+            dtype=np.float64,
+        )
+
+        np.testing.assert_array_equal(result, expected)
+        assert result.dtype == np.float64
+        assert {call.kwargs["workers"] for call in cdist_spy.call_args_list} == {-1}
+
+
+def test_linked_somatic_padding_counts_each_chain(fixture_setup: SadieFixture):
+    source = pd.read_feather(fixture_setup.get_catnap_joined_with_mutational_analysis()).iloc[:2]
+    linked = LinkedAirrTable(source, key_column="cellid")
+    linked["cdr3_aa_heavy"] = ["AAAA", "BBBB"]
+    linked.at[0, "mutations_heavy"] = np.array(["A1T", "A1T", "C94G"], dtype=object)
+    linked.at[1, "mutations_heavy"] = np.array(["A1T", "C94G"], dtype=object)
+    linked.at[0, "mutations_light"] = np.array(["A1T", "D93E"], dtype=object)
+    linked.at[1, "mutations_light"] = np.array(["A1T", "D93E"], dtype=object)
+    cluster = Cluster(
+        linked,
+        lookup=["cdr3_aa_heavy"],
+        pad_somatic=True,
+        include_only_v_gene=True,
+    )
+
+    result = cluster._get_distance_df(linked)
+
+    np.testing.assert_array_equal(result, np.array([[0.0, 1.0], [1.0, 0.0]]))
+    assert linked.at[0, "mutations_heavy"] == ["A1T", "A1T"]
+
+
+def test_linked_cluster_preserves_exact_output_with_reconstruction(fixture_setup: SadieFixture):
     ids = ["VRC26.05", "PCT64-18B", "VRC26.06", "PCT64-18C", "VRC26.08", "PCT64-18D"]
     source = pd.read_feather(fixture_setup.get_catnap_joined_with_mutational_analysis())
     linked = LinkedAirrTable(source.set_index("cellid").loc[ids].reset_index(), key_column="cellid")
@@ -43,11 +112,10 @@ def test_linked_cluster_preserves_exact_output_without_reconstruction(fixture_se
     ]
     cluster = Cluster(linked, groupby=["v_call_top_heavy", "v_call_top_light"])
 
-    with patch.object(LinkedAirrTable, "__init__", side_effect=AssertionError("unexpected reconstruction")):
-        result = cluster.cluster(10)
+    result = cluster.cluster(10)
 
     pd.testing.assert_frame_equal(pd.DataFrame(result), expected)
-    assert result is cluster.airrtable
+    assert result is not cluster.airrtable
     assert isinstance(result, LinkedAirrTable)
     assert result.key_column == "cellid"
     assert result.suffixes == ["_heavy", "_light"]

--- a/tests/unit/cluster/test_cluster_differential.py
+++ b/tests/unit/cluster/test_cluster_differential.py
@@ -1,0 +1,724 @@
+from __future__ import annotations
+
+import copy
+import itertools
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import pytest
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+from Levenshtein import distance as lev_distance
+from rapidfuzz.process import cdist as rapidfuzz_cdist
+from sklearn.metrics import pairwise_distances
+
+from sadie.airr import AirrTable, LinkedAirrTable
+from sadie.cluster import Cluster
+
+_DEFAULT_LOOKUP = ["cdr1_aa", "cdr2_aa", "cdr3_aa"]
+_UNLINKED_LOOKUPS = [
+    _DEFAULT_LOOKUP,
+    ["cdr3_aa"],
+    ["cdr3_aa", "cdr1_aa"],
+    ["cdr1_aa", "cdr1_aa"],
+]
+_LINKED_LOOKUPS = [
+    _DEFAULT_LOOKUP,
+    ["cdr3_aa_heavy"],
+    ["cdr3_aa_light", "cdr1_aa_heavy"],
+    ["cdr1_aa_heavy", "cdr1_aa_heavy"],
+]
+_LOOKUP_COLUMNS = [
+    "cdr1_aa_heavy",
+    "cdr2_aa_heavy",
+    "cdr3_aa_heavy",
+    "cdr1_aa_light",
+    "cdr2_aa_light",
+    "cdr3_aa_light",
+]
+_GREEDY_ENABLED = os.environ.get("SADIE_CLUSTER_GREEDY") == "1"
+_GREEDY_EXAMPLES = int(os.environ.get("SADIE_CLUSTER_GREEDY_EXAMPLES", "40000"))
+_GREEDY_THREADED_EXAMPLES = int(os.environ.get("SADIE_CLUSTER_THREADED_EXAMPLES", "200"))
+_GREEDY_PROGRESS = 0
+_GREEDY_THREADED_PROGRESS = 0
+pytestmark = pytest.mark.filterwarnings("ignore:DataFrame columns are not unique")
+
+
+class _LegacyCluster(Cluster):
+    """The exact distance kernel from main at 973395e4."""
+
+    def _get_distance_df(self, df: pd.DataFrame) -> Any:
+        if self.pad_somatic:
+            _lookup = self.lookup + self.pad_somatic_values
+            if self.include_only_v_gene:
+                if self._type == "linked":
+                    df["mutations_heavy"] = df["mutations_heavy"].apply(self._get_v_gene_only)
+                    df["mutations_light"] = df["mutations_light"].apply(self._get_v_gene_only)
+                else:
+                    df["mutations"] = df["mutations"].apply(self._get_v_gene_only)
+        else:
+            _lookup = self.lookup
+        df_lookup = df[_lookup].to_dict(orient="index")
+
+        def calc_lev(x: npt.ArrayLike, y: npt.ArrayLike) -> float:
+            dist = 0
+            for metric in self.lookup:
+                dist += lev_distance(str(df_lookup[x[0]][metric]), str(df_lookup[y[0]][metric]))  # type: ignore[index]
+            if self.pad_somatic and x[0] != y[0]:  # type: ignore[index]
+                if len(self.pad_somatic_values) == 2:
+                    mutations_1_heavy = df_lookup[x[0]][self.pad_somatic_values[0]]  # type: ignore[index]
+                    mutations_2_heavy = df_lookup[y[0]][self.pad_somatic_values[0]]  # type: ignore[index]
+                    mutations_1_light = df_lookup[x[0]][self.pad_somatic_values[1]]  # type: ignore[index]
+                    mutations_2_light = df_lookup[y[0]][self.pad_somatic_values[1]]  # type: ignore[index]
+                    subtract_all = len(np.intersect1d(mutations_1_heavy, mutations_2_heavy)) + len(
+                        np.intersect1d(mutations_1_light, mutations_2_light)
+                    )
+                else:
+                    mutations_1 = df_lookup[x[0]][self.pad_somatic_values[0]]  # type: ignore[index]
+                    mutations_2 = df_lookup[y[0]][self.pad_somatic_values[0]]  # type: ignore[index]
+                    subtract_all = len(np.intersect1d(mutations_1, mutations_2))
+                dist -= subtract_all
+            return max(dist, 0)
+
+        X: npt.ArrayLike = np.array(df.index).reshape(-1, 1)
+        return pairwise_distances(X, metric=calc_lev, n_jobs=-1)
+
+
+class _WeirdMutation(str):
+    def __hash__(self) -> int:
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+
+class _ChangingLookup:
+    def __init__(self):
+        self.calls = 0
+
+    def __str__(self) -> str:
+        self.calls += 1
+        return "A" if self.calls % 2 else "B"
+
+
+@st.composite
+def _mutation_token(draw: st.DrawFn) -> str:
+    amino_acid = st.sampled_from(list("ACDEFGHIKLMNPQRSTVWYÅ"))
+    position = st.one_of(st.sampled_from([0, 1, 92, 93, 94, 95, 120]), st.integers(min_value=0, max_value=150))
+    return f"{draw(amino_acid)}{draw(position)}{draw(st.sampled_from(['', '.1']))}{draw(amino_acid)}"
+
+
+_LOOKUP_VALUE = st.one_of(
+    st.text(max_size=12),
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-1000, max_value=1000),
+    st.floats(width=32, allow_nan=True, allow_infinity=True),
+    st.just(pd.NA),
+)
+_MUTATION_SPEC = st.tuples(
+    st.sampled_from(["list", "array"]),
+    st.lists(_mutation_token(), min_size=0, max_size=7).map(tuple),
+)
+_BOUNDARY_ATOM = st.one_of(
+    st.text(max_size=6),
+    st.binary(max_size=6),
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-10, max_value=10),
+    st.floats(width=32, allow_nan=True, allow_infinity=True),
+    st.just(pd.NA),
+)
+
+
+@st.composite
+def _boundary_mutation_spec(draw: st.DrawFn) -> tuple[str, Any]:
+    kind = draw(st.sampled_from(["scalar", "list", "tuple", "set", "dict", "array0", "array1", "array2"]))
+    if kind in {"scalar", "array0"}:
+        value = draw(_BOUNDARY_ATOM)
+    elif kind == "set":
+        value = draw(st.sets(_BOUNDARY_ATOM, max_size=4))
+    elif kind == "dict":
+        value = draw(st.dictionaries(st.text(max_size=4), _BOUNDARY_ATOM, max_size=4))
+    elif kind == "array2":
+        value = draw(st.lists(_BOUNDARY_ATOM, min_size=4, max_size=4).map(tuple))
+    else:
+        value = draw(st.lists(_BOUNDARY_ATOM, max_size=5).map(tuple))
+    return kind, value
+
+
+@st.composite
+def _cluster_case(draw: st.DrawFn, min_rows: int = 2, max_rows: int = 8) -> dict[str, Any]:
+    row_count = draw(st.integers(min_value=min_rows, max_value=max_rows))
+    lookup_rows = draw(
+        st.lists(
+            st.lists(_LOOKUP_VALUE, min_size=6, max_size=6).map(tuple),
+            min_size=row_count,
+            max_size=row_count,
+        )
+    )
+    mutation_heavy = draw(st.lists(_MUTATION_SPEC, min_size=row_count, max_size=row_count))
+    mutation_light = draw(st.lists(_MUTATION_SPEC, min_size=row_count, max_size=row_count))
+    groups = draw(st.lists(st.sampled_from(["g0", "g1", "g2", "", "Å"]), min_size=row_count, max_size=row_count))
+    batches = draw(st.lists(st.sampled_from(["b0", "b1", ""]), min_size=row_count, max_size=row_count))
+    index_kind = draw(st.sampled_from(["range", "integer", "string"]))
+    index_start = draw(st.integers(min_value=-1000, max_value=1000))
+    if index_kind == "range":
+        index = list(range(index_start, index_start + row_count))
+    elif index_kind == "integer":
+        step = draw(st.integers(min_value=2, max_value=9))
+        index = [index_start + step * row for row in range(row_count)]
+    else:
+        prefix = draw(st.text(alphabet=list("abÅ_"), max_size=4))
+        index = [f"{prefix}:{index_start + row}" for row in range(row_count)]
+
+    return {
+        "linked": draw(st.booleans()),
+        "lookup_rows": lookup_rows,
+        "mutation_heavy": mutation_heavy,
+        "mutation_light": mutation_light,
+        "groups": groups,
+        "batches": batches,
+        "index": index,
+        "lookup_choice": draw(st.integers(min_value=0, max_value=3)),
+        "pad_somatic": draw(st.booleans()),
+        "include_only_v_gene": draw(st.booleans()),
+        "groupby_choice": draw(st.integers(min_value=0, max_value=2)),
+        "linkage": draw(st.sampled_from(["single", "average", "complete"])),
+        "distance_threshold": draw(st.integers(min_value=0, max_value=15)),
+    }
+
+
+@st.composite
+def _threaded_cluster_case(draw: st.DrawFn) -> dict[str, Any]:
+    row_count = draw(st.sampled_from([149, 150, 151]))
+    case = _fixed_case(draw(st.booleans()), row_count)
+    lookup_palette = draw(st.lists(st.tuples(*[_LOOKUP_VALUE for _ in range(6)]), min_size=1, max_size=4))
+    heavy_palette = draw(st.lists(_MUTATION_SPEC, min_size=1, max_size=4))
+    light_palette = draw(st.lists(_MUTATION_SPEC, min_size=1, max_size=4))
+    case.update(
+        {
+            "lookup_rows": [lookup_palette[row % len(lookup_palette)] for row in range(row_count)],
+            "mutation_heavy": [heavy_palette[row % len(heavy_palette)] for row in range(row_count)],
+            "mutation_light": [light_palette[row % len(light_palette)] for row in range(row_count)],
+            "lookup_choice": draw(st.integers(min_value=0, max_value=3)),
+            "pad_somatic": draw(st.booleans()),
+            "include_only_v_gene": draw(st.booleans()),
+        }
+    )
+    return case
+
+
+def _materialize_mutation(spec: tuple[str, tuple[str, ...]]) -> list[str] | np.ndarray:
+    kind, mutations = spec
+    return list(mutations) if kind == "list" else np.array(mutations, dtype=object)
+
+
+def _materialize_boundary_mutation(spec: tuple[str, Any]) -> Any:
+    kind, value = spec
+    if kind == "scalar":
+        return copy.deepcopy(value)
+    if kind == "list":
+        return list(copy.deepcopy(value))
+    if kind == "tuple":
+        return tuple(copy.deepcopy(value))
+    if kind == "set":
+        return set(copy.deepcopy(value))
+    if kind == "dict":
+        return dict(copy.deepcopy(value))
+    if kind == "array0":
+        return np.array(copy.deepcopy(value), dtype=object)
+    if kind == "array1":
+        return np.array(copy.deepcopy(value), dtype=object)
+    return np.array(copy.deepcopy(value), dtype=object).reshape(2, 2)
+
+
+def _lookup(case: dict[str, Any]) -> list[str]:
+    choices = _LINKED_LOOKUPS if case["linked"] else _UNLINKED_LOOKUPS
+    return list(choices[case["lookup_choice"]])
+
+
+def _resolved_lookup(case: dict[str, Any]) -> list[str]:
+    lookup = _lookup(case)
+    if case["linked"] and lookup == _DEFAULT_LOOKUP:
+        return [f"{column}_heavy" for column in lookup] + [f"{column}_light" for column in lookup]
+    return lookup
+
+
+def _groupby(case: dict[str, Any]) -> list[str] | None:
+    return [None, ["group"], ["group", "batch"]][case["groupby_choice"]]
+
+
+def _distance_frame(case: dict[str, Any]) -> pd.DataFrame:
+    linked = case["linked"]
+    lookup_columns = _LOOKUP_COLUMNS if linked else _DEFAULT_LOOKUP
+    lookup_indexes = range(6) if linked else range(3)
+    data: dict[str, Any] = {
+        column: [row[column_index] for row in case["lookup_rows"]]
+        for column, column_index in zip(lookup_columns, lookup_indexes)
+    }
+    if linked:
+        data["mutations_heavy"] = [_materialize_mutation(spec) for spec in case["mutation_heavy"]]
+        data["mutations_light"] = [_materialize_mutation(spec) for spec in case["mutation_light"]]
+        data["cellid"] = [f"cell-{row}" for row in range(len(case["lookup_rows"]))]
+    else:
+        data["mutations"] = [_materialize_mutation(spec) for spec in case["mutation_heavy"]]
+        data["sequence_id"] = [f"sequence-{row}" for row in range(len(case["lookup_rows"]))]
+    data["group"] = case["groups"]
+    data["batch"] = case["batches"]
+    return pd.DataFrame(data, index=case["index"], dtype=object)
+
+
+@lru_cache(maxsize=1)
+def _linked_template() -> pd.DataFrame:
+    fixture = Path(__file__).resolve().parents[2] / "data/fixtures/airr_tables/joined_airrtable_with_mutational.feather"
+    return pd.read_feather(fixture)
+
+
+def _table(case: dict[str, Any]) -> AirrTable | LinkedAirrTable:
+    generated = _distance_frame(case)
+    if not case["linked"]:
+        return AirrTable(generated, key_column="sequence_id")
+
+    row_count = len(generated)
+    source = _linked_template()
+    table = source.iloc[np.arange(row_count) % len(source)].copy(deep=True)
+    table.index = generated.index
+    for column in generated.columns:
+        values = np.empty(row_count, dtype=object)
+        for row, value in enumerate(generated[column]):
+            values[row] = copy.deepcopy(value)
+        table[column] = values
+    return LinkedAirrTable(table, key_column="cellid")
+
+
+def _distance_cluster(cluster_type: type[Cluster], case: dict[str, Any]) -> Cluster:
+    cluster = cluster_type.__new__(cluster_type)
+    cluster.lookup = _resolved_lookup(case)
+    cluster.pad_somatic = case["pad_somatic"]
+    cluster.include_only_v_gene = case["include_only_v_gene"]
+    cluster._type = "linked" if case["linked"] else "unlinked"
+    cluster.pad_somatic_values = ["mutations_heavy", "mutations_light"] if case["linked"] else ["mutations"]
+    return cluster
+
+
+def _assert_distance_equivalent(case: dict[str, Any]) -> None:
+    legacy_frame = _distance_frame(case)
+    current_frame = _distance_frame(case)
+    legacy = _distance_cluster(_LegacyCluster, case)._get_distance_df(legacy_frame)
+    current = _distance_cluster(Cluster, case)._get_distance_df(current_frame)
+
+    np.testing.assert_array_equal(current, legacy)
+    pd.testing.assert_frame_equal(current_frame, legacy_frame)
+    assert current.dtype == np.float64
+    assert current.shape == (len(current_frame), len(current_frame))
+    np.testing.assert_array_equal(current, current.T)
+    np.testing.assert_array_equal(np.diag(current), np.zeros(len(current_frame)))
+    assert np.all(current >= 0)
+    assert np.all(current == np.floor(current))
+
+
+def _run_cluster(
+    cluster_type: type[Cluster], case: dict[str, Any]
+) -> tuple[AirrTable | LinkedAirrTable, Cluster, AirrTable | LinkedAirrTable]:
+    input_table = _table(case)
+    cluster = cluster_type(
+        input_table,
+        linkage=case["linkage"],
+        groupby=_groupby(case),
+        lookup=_lookup(case),
+        pad_somatic=case["pad_somatic"],
+        include_only_v_gene=case["include_only_v_gene"],
+    )
+    result = cluster.cluster(case["distance_threshold"])
+    return input_table, cluster, result
+
+
+def _assert_model_equivalent(current: Any, legacy: Any) -> None:
+    assert (current is None) == (legacy is None)
+    if current is None:
+        return
+    assert type(current) is type(legacy)
+    for attribute in ("labels_", "children_", "distances_"):
+        np.testing.assert_array_equal(getattr(current, attribute), getattr(legacy, attribute))
+    assert current.n_leaves_ == legacy.n_leaves_
+    assert current.n_connected_components_ == legacy.n_connected_components_
+
+
+def _assert_cluster_equivalent(case: dict[str, Any]) -> None:
+    legacy_input, legacy_cluster, legacy_result = _run_cluster(_LegacyCluster, case)
+    current_input, current_cluster, current_result = _run_cluster(Cluster, case)
+
+    assert type(current_result) is type(legacy_result)
+    assert current_result.key_column == legacy_result.key_column
+    assert current_result.verified == legacy_result.verified
+    if isinstance(current_result, LinkedAirrTable):
+        assert current_result.suffixes == legacy_result.suffixes
+    pd.testing.assert_frame_equal(pd.DataFrame(current_result), pd.DataFrame(legacy_result), check_exact=True)
+    pd.testing.assert_frame_equal(pd.DataFrame(current_input), pd.DataFrame(legacy_input), check_exact=True)
+    pd.testing.assert_frame_equal(
+        pd.DataFrame(current_cluster.airrtable), pd.DataFrame(legacy_cluster.airrtable), check_exact=True
+    )
+    np.testing.assert_array_equal(current_cluster.distance_df, legacy_cluster.distance_df)
+    _assert_model_equivalent(current_cluster.model, legacy_cluster.model)
+    assert (current_result is current_cluster.airrtable) == (legacy_result is legacy_cluster.airrtable)
+    assert (current_result is current_input) == (legacy_result is legacy_input)
+
+
+def _fixed_case(linked: bool, row_count: int = 6) -> dict[str, Any]:
+    return {
+        "linked": linked,
+        "lookup_rows": [
+            (f"A{row}", f"B{row % 3}", f"C{row % 2}", f"D{row}", f"E{row % 3}", f"F{row % 2}")
+            for row in range(row_count)
+        ],
+        "mutation_heavy": [
+            ("array" if row % 2 else "list", ("A0T", "C93G", "G94A", "A0T")[: row % 5]) for row in range(row_count)
+        ],
+        "mutation_light": [
+            ("list" if row % 2 else "array", ("T1C", "G93A", "C120T")[: row % 4]) for row in range(row_count)
+        ],
+        "groups": [f"g{row % 3}" for row in range(row_count)],
+        "batches": [f"b{row % 2}" for row in range(row_count)],
+        "index": [10 + row * 3 for row in range(row_count)],
+        "lookup_choice": 0,
+        "pad_somatic": False,
+        "include_only_v_gene": False,
+        "groupby_choice": 0,
+        "linkage": "complete",
+        "distance_threshold": 3,
+    }
+
+
+def _assert_raw_mutation_outcome_equivalent(mutations: list[Any]) -> None:
+    case = _fixed_case(False, len(mutations))
+    case["lookup_choice"] = 1
+    case["pad_somatic"] = True
+
+    def frame() -> pd.DataFrame:
+        values = np.empty(len(mutations), dtype=object)
+        for row, mutation in enumerate(mutations):
+            values[row] = copy.deepcopy(mutation)
+        return pd.DataFrame(
+            {"cdr3_aa": ["AAAA" if row % 2 == 0 else "TTTT" for row in range(len(mutations))], "mutations": values},
+            index=[10 + row * 3 for row in range(len(mutations))],
+            dtype=object,
+        )
+
+    def outcome(cluster_type: type[Cluster], source: pd.DataFrame) -> tuple[str, Any]:
+        try:
+            return "result", _distance_cluster(cluster_type, case)._get_distance_df(source)
+        except Exception as error:
+            return "error", error
+
+    legacy_frame = frame()
+    current_frame = frame()
+    legacy_outcome = outcome(_LegacyCluster, legacy_frame)
+    current_outcome = outcome(Cluster, current_frame)
+
+    assert current_outcome[0] == legacy_outcome[0]
+    if current_outcome[0] == "result":
+        np.testing.assert_array_equal(current_outcome[1], legacy_outcome[1])
+        pd.testing.assert_frame_equal(current_frame, legacy_frame)
+    else:
+        # NumPy can reverse operand names in equivalent TypeError messages.
+        assert type(current_outcome[1]) is type(legacy_outcome[1])
+
+
+@given(case=_cluster_case(min_rows=1, max_rows=12))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_generated_distance_kernel_matches_legacy(case: dict[str, Any]):
+    _assert_distance_equivalent(case)
+
+
+@given(case=_cluster_case(min_rows=2, max_rows=8))
+@settings(max_examples=150, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_generated_cluster_output_matches_legacy(case: dict[str, Any]):
+    _assert_cluster_equivalent(case)
+
+
+@given(left=_boundary_mutation_spec(), right=_boundary_mutation_spec(), singleton=st.booleans())
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_generated_mutation_boundaries_match_legacy(left: tuple[str, Any], right: tuple[str, Any], singleton: bool):
+    mutations = [_materialize_boundary_mutation(left)]
+    if not singleton:
+        mutations.append(_materialize_boundary_mutation(right))
+    _assert_raw_mutation_outcome_equivalent(mutations)
+
+
+def test_bounded_exhaustive_lookup_values_match_legacy():
+    values = ["".join(value) for length in range(5) for value in itertools.product("ABÅ", repeat=length)]
+    values += ["é", "e\u0301", "🙂", "\0", "", " ", None, np.nan, pd.NA, -1, 0, 1]
+    case = _fixed_case(False, len(values))
+    case["lookup_choice"] = 1
+    case["lookup_rows"] = [("", "", value, "", "", "") for value in values]
+    _assert_distance_equivalent(case)
+
+
+@pytest.mark.parametrize("representation", ["list", "array"])
+@pytest.mark.parametrize("include_only_v_gene", [False, True])
+def test_bounded_exhaustive_mutation_lists_match_legacy(representation: str, include_only_v_gene: bool):
+    tokens = ("A0T", "C93G", "G94A", "T120C")
+    mutation_lists = [mutations for length in range(4) for mutations in itertools.product(tokens, repeat=length)]
+    row_count = len(mutation_lists) * 2
+    case = _fixed_case(False, row_count)
+    case["lookup_choice"] = 1
+    case["lookup_rows"] = [
+        ("", "", "AAAA" if block == 0 else "TTTT", "", "", "") for block in range(2) for _ in mutation_lists
+    ]
+    case["mutation_heavy"] = [(representation, mutations) for _ in range(2) for mutations in mutation_lists]
+    case["pad_somatic"] = True
+    case["include_only_v_gene"] = include_only_v_gene
+    _assert_distance_equivalent(case)
+
+
+def test_bounded_exhaustive_linked_chain_padding_matches_legacy():
+    tokens = ("A0T", "C94G")
+    mutation_lists = [mutations for length in range(3) for mutations in itertools.product(tokens, repeat=length)]
+    combinations = list(itertools.product(mutation_lists, repeat=2))
+    case = _fixed_case(True, len(combinations))
+    case["lookup_choice"] = 1
+    case["lookup_rows"] = [("", "", "AAAA" if row % 2 else "TTTT", "", "", "") for row in range(len(combinations))]
+    case["mutation_heavy"] = [("list", heavy) for heavy, _ in combinations]
+    case["mutation_light"] = [("array", light) for _, light in combinations]
+    case["pad_somatic"] = True
+    _assert_distance_equivalent(case)
+
+
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.greedy
+@pytest.mark.skipif(not _GREEDY_ENABLED, reason="set SADIE_CLUSTER_GREEDY=1 to run exhaustive option combinations")
+def test_cluster_option_cross_product_matches_legacy(linked: bool):
+    for linkage, groupby_choice, lookup_choice, pad_somatic, include_only_v_gene, threshold in itertools.product(
+        ["single", "average", "complete"],
+        range(3),
+        range(4),
+        [False, True],
+        [False, True],
+        [0, 3, 12],
+    ):
+        case = _fixed_case(linked)
+        case.update(
+            {
+                "linkage": linkage,
+                "groupby_choice": groupby_choice,
+                "lookup_choice": lookup_choice,
+                "pad_somatic": pad_somatic,
+                "include_only_v_gene": include_only_v_gene,
+                "distance_threshold": threshold,
+            }
+        )
+        _assert_cluster_equivalent(case)
+
+
+@pytest.mark.parametrize("row_count", [149, 150, 151])
+@pytest.mark.parametrize("pad_somatic", [False, True])
+def test_thread_boundary_matches_legacy_and_is_deterministic(row_count: int, pad_somatic: bool):
+    case = _fixed_case(False, row_count)
+    case["pad_somatic"] = pad_somatic
+    legacy_frame = _distance_frame(case)
+    expected = _distance_cluster(_LegacyCluster, case)._get_distance_df(legacy_frame)
+
+    results = []
+    with patch("sadie.cluster.cluster.cdist", wraps=rapidfuzz_cdist) as cdist_spy:
+        for _ in range(10):
+            result = _distance_cluster(Cluster, case)._get_distance_df(_distance_frame(case))
+            np.testing.assert_array_equal(result, expected)
+            results.append(result)
+    assert {call.kwargs["workers"] for call in cdist_spy.call_args_list} == ({-1} if row_count >= 150 else {1})
+    for result in results[1:]:
+        np.testing.assert_array_equal(result, results[0])
+
+
+@pytest.mark.parametrize("linked", [False, True])
+def test_grouped_threaded_cluster_matches_legacy(linked: bool):
+    case = _fixed_case(linked, 300)
+    case.update(
+        {
+            "groups": ["g0"] * 150 + ["g1"] * 150,
+            "lookup_choice": 2,
+            "pad_somatic": True,
+            "include_only_v_gene": True,
+            "groupby_choice": 1,
+        }
+    )
+    with patch("sadie.cluster.cluster.cdist", wraps=rapidfuzz_cdist) as cdist_spy:
+        _assert_cluster_equivalent(case)
+    assert {call.kwargs["workers"] for call in cdist_spy.call_args_list} == {-1}
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("A1T", "A1T"),
+        (b"A1T", b"A1T"),
+        (1, 1),
+        (np.nan, np.nan),
+        (None, None),
+        ({"A1T"}, {"A1T"}),
+        ({"mutation": "A1T"}, {"mutation": "A1T"}),
+        ([["A1T"]], [["A1T"]]),
+        ([1, "1"], ["1"]),
+        ([np.nan], [np.nan]),
+        ([""], ["\0"]),
+        (pd.NA, pd.NA),
+        ([_WeirdMutation("A")], [_WeirdMutation("B")]),
+    ],
+)
+def test_malformed_mutation_cells_preserve_legacy_outcome(left: Any, right: Any):
+    _assert_raw_mutation_outcome_equivalent([left, right])
+
+
+@pytest.mark.parametrize("mutation", ["A1T", b"A1T", 1, np.nan, None, {"A1T"}, [["A1T"]], pd.NA])
+def test_singleton_malformed_mutation_cells_match_legacy(mutation: Any):
+    _assert_raw_mutation_outcome_equivalent([mutation])
+
+
+@pytest.mark.parametrize("pad_somatic_values", [[], ["mutations", "extra", "third"]])
+def test_nonstandard_padding_columns_match_legacy(pad_somatic_values: list[str]):
+    case = _fixed_case(False, 2)
+    case.update({"lookup_choice": 1, "pad_somatic": True})
+    frame = _distance_frame(case)
+    frame["extra"] = [["A0T"], ["A0T"]]
+    frame["third"] = [["A0T"], ["A0T"]]
+
+    def outcome(cluster_type: type[Cluster]) -> tuple[str, Any]:
+        cluster = _distance_cluster(cluster_type, case)
+        cluster.pad_somatic_values = pad_somatic_values
+        try:
+            return "result", cluster._get_distance_df(frame.copy(deep=True))
+        except Exception as error:
+            return "error", error
+
+    legacy = outcome(_LegacyCluster)
+    current = outcome(Cluster)
+    assert current[0] == legacy[0]
+    if current[0] == "result":
+        np.testing.assert_array_equal(current[1], legacy[1])
+    else:
+        assert type(current[1]) is type(legacy[1])
+
+
+def test_stateful_lookup_objects_match_legacy():
+    case = _fixed_case(False, 2)
+    case["lookup_choice"] = 1
+
+    def frame() -> pd.DataFrame:
+        result = _distance_frame(case)
+        result["cdr3_aa"] = [_ChangingLookup(), _ChangingLookup()]
+        return result
+
+    legacy = _distance_cluster(_LegacyCluster, case)._get_distance_df(frame())
+    with patch("sadie.cluster.cluster.cdist", wraps=rapidfuzz_cdist) as cdist_spy:
+        current = _distance_cluster(Cluster, case)._get_distance_df(frame())
+    np.testing.assert_array_equal(current, legacy)
+    cdist_spy.assert_not_called()
+
+
+def test_empty_distance_matrix_matches_legacy():
+    case = _fixed_case(False, 0)
+    case["lookup_choice"] = 1
+    try:
+        legacy = _distance_cluster(_LegacyCluster, case)._get_distance_df(_distance_frame(case))
+    except Exception as legacy_error:
+        with pytest.raises(type(legacy_error)):
+            _distance_cluster(Cluster, case)._get_distance_df(_distance_frame(case))
+    else:
+        current = _distance_cluster(Cluster, case)._get_distance_df(_distance_frame(case))
+        np.testing.assert_array_equal(current, legacy)
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        [0, np.nan],
+        [0, np.inf],
+        [0, pd.NaT],
+        [0, 0],
+        pd.Index([1, "1"], dtype=object),
+        pd.Index([("a", 1), ("b", 2)]),
+        pd.MultiIndex.from_tuples([("a", 1), ("b", 2)]),
+        pd.date_range("2020-01-01", periods=2),
+        pd.DatetimeIndex(["2020-01-01", pd.NaT]),
+        pd.to_timedelta([1, 2], unit="D"),
+        pd.TimedeltaIndex([pd.Timedelta(days=1), pd.NaT]),
+    ],
+)
+def test_index_result_or_error_matches_legacy(index: Any):
+    row_count = len(index)
+    case = _fixed_case(False, row_count)
+    case["lookup_choice"] = 1
+    case["index"] = index
+    legacy_frame = _distance_frame(case)
+    current_frame = _distance_frame(case)
+
+    def outcome(cluster_type: type[Cluster], source: pd.DataFrame) -> tuple[str, Any]:
+        try:
+            return "result", _distance_cluster(cluster_type, case)._get_distance_df(source)
+        except Exception as error:
+            return "error", error
+
+    legacy_outcome = outcome(_LegacyCluster, legacy_frame)
+    current_outcome = outcome(Cluster, current_frame)
+    assert current_outcome[0] == legacy_outcome[0]
+    if current_outcome[0] == "result":
+        np.testing.assert_array_equal(current_outcome[1], legacy_outcome[1])
+    else:
+        assert type(current_outcome[1]) is type(legacy_outcome[1])
+
+
+@pytest.mark.greedy
+@pytest.mark.skipif(not _GREEDY_ENABLED, reason="set SADIE_CLUSTER_GREEDY=1 to fuzz the threaded boundary")
+@given(case=_threaded_cluster_case())
+@settings(
+    max_examples=_GREEDY_THREADED_EXAMPLES,
+    deadline=None,
+    derandomize=True,
+    database=None,
+    phases=(Phase.generate, Phase.shrink),
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
+)
+def test_greedy_threaded_distance_matches_legacy(case: dict[str, Any]):
+    global _GREEDY_THREADED_PROGRESS
+    _assert_distance_equivalent(case)
+    _GREEDY_THREADED_PROGRESS += 1
+    if _GREEDY_THREADED_PROGRESS % 10 == 0:
+        print(
+            f"greedy threaded equivalence: {_GREEDY_THREADED_PROGRESS}/{_GREEDY_THREADED_EXAMPLES}",
+            flush=True,
+        )
+
+
+@pytest.mark.greedy
+@pytest.mark.skipif(not _GREEDY_ENABLED, reason="set SADIE_CLUSTER_GREEDY=1 to run the multi-hour suite")
+@given(
+    case=_cluster_case(min_rows=2, max_rows=24),
+    left=_boundary_mutation_spec(),
+    right=_boundary_mutation_spec(),
+)
+@settings(
+    max_examples=_GREEDY_EXAMPLES,
+    deadline=None,
+    derandomize=True,
+    database=None,
+    phases=(Phase.generate, Phase.shrink),
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_greedy_generated_cluster_and_distance_match_legacy(
+    case: dict[str, Any], left: tuple[str, Any], right: tuple[str, Any]
+):
+    global _GREEDY_PROGRESS
+    _assert_distance_equivalent(case)
+    _assert_cluster_equivalent(case)
+    _assert_raw_mutation_outcome_equivalent(
+        [_materialize_boundary_mutation(left), _materialize_boundary_mutation(right)]
+    )
+    _GREEDY_PROGRESS += 1
+    if _GREEDY_PROGRESS % 250 == 0:
+        print(f"greedy cluster equivalence: {_GREEDY_PROGRESS}/{_GREEDY_EXAMPLES}", flush=True)


### PR DESCRIPTION
## Summary

- replace Python-level pairwise Levenshtein calls with RapidFuzz's native threaded distance matrices for every clustering mode, including `pad_somatic`
- calculate somatic padding from an inverted mutation-to-row index while preserving per-chain intersections, duplicate handling, V-gene filtering, and distance clamping
- preserve linked/unlinked and grouped/ungrouped output values, ordering, reconstruction, metadata, and input side effects

## Performance

- linked 219-row distance matrix: 29.4x faster without somatic padding
- linked 219-row distance matrix: 81.6x faster with somatic padding
- linked 219-row distance matrix: 86.2x faster with somatic padding and V-gene-only filtering
- multiprocessing was benchmarked but omitted because process startup, IPC, and worker copies made it substantially slower than the native-threaded/vectorized path

## Validation

- 6 focused clustering tests
- 174 unit tests
- 3 integration tests
- exact merge-base comparison across 32 option combinations, including distance matrices, outputs, labels, types, metadata, reconstruction, and input side effects
- Pyright, pre-commit, Poetry lock validation, and CodeRabbit (0 issues)

Closes #278
